### PR TITLE
fix g_file_copy flags type

### DIFF
--- a/GGGG.c
+++ b/GGGG.c
@@ -186,7 +186,7 @@ gboolean gCopyFile (const gchar*  source, const gchar*  dest, gboolean  overwrit
     GError*  gerr = {0};
     GFile*   fsrc = {0};
     GFile*   fdest = {0};
-    int      owflag = G_FILE_COPY_OVERWRITE;
+    GFileCopyFlags owflag = G_FILE_COPY_OVERWRITE;
     if(overwrite )
     {
         owflag = G_FILE_COPY_NONE;

--- a/GGGG.cpp
+++ b/GGGG.cpp
@@ -226,7 +226,7 @@ gboolean gCopyFile (const gchar*  source, const gchar*  dest, gboolean  overwrit
     GError*  gerr = {0};
     GFile*   fsrc = {0};
     GFile*   fdest = {0};
-    int      owflag = G_FILE_COPY_OVERWRITE;
+    GFileCopyFlags owflag = G_FILE_COPY_OVERWRITE;
     if(overwrite )
     {
         owflag = G_FILE_COPY_NONE;


### PR DESCRIPTION
The flags argument is not an int, so use the correct type to avoid compile-time warnings.